### PR TITLE
docs: remove doc_auto_cfg, which was merged into doc_cfg

### DIFF
--- a/crates/jlabel-question/src/lib.rs
+++ b/crates/jlabel-question/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! HTS-style full-context label question parser and matcher.
 //!


### PR DESCRIPTION
Fixes: #87 