### PR TITLE
docs: remove doc_auto_cfg for jlabel

### DIFF
--- a/crates/jlabel/src/lib.rs
+++ b/crates/jlabel/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! HTS-style full-context label structure and parser/serializer from/to string.
 //!


### PR DESCRIPTION
Fixes: #87 